### PR TITLE
Bootstrap.init now uses the relative location of the executing assemby

### DIFF
--- a/bin/DevILSharp.nuspec
+++ b/bin/DevILSharp.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>DevILSharp</id>
-        <version>0.0.11</version>
+        <version>0.0.12</version>
         <authors>krauthaufen</authors>
         <owners>krauthaufen</owners>
         <licenseUrl>http://opensource.org/licenses/Apache-2.0</licenseUrl>


### PR DESCRIPTION
Bootstrap.init now uses the relative location of the executing assembly instead of current path for extracting native dependencies
